### PR TITLE
Migrate to BSD License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,29 @@
-MIT License
+BSD 3-Clause License
 
-Copyright (c) 2016 CIR-KIT
+Copyright (c) 2016, CIR-KIT
+All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/waypoint_generator/package.xml
+++ b/waypoint_generator/package.xml
@@ -5,7 +5,7 @@
   <description>The waypoint_generator package</description>
 
   <maintainer email="k104009y@mail.kyutech.jp">Ariyu</maintainer>
-  <license>MIT</license>
+  <license>BSD</license>
 
   <url type="repository">https://github.com/CIR-KIT/waypoint_manager.git</url>
   <url type="bugtracker">https://github.com/CIR-KIT/waypoint_manager/issues</url>

--- a/waypoint_generator/package.xml
+++ b/waypoint_generator/package.xml
@@ -9,7 +9,7 @@
 
   <url type="repository">https://github.com/CIR-KIT/waypoint_manager.git</url>
   <url type="bugtracker">https://github.com/CIR-KIT/waypoint_manager/issues</url>
-  <!-- TODO:write this <author email="jane.doe@example.com">Jane Doe</author> -->
+  <author email="cirkit.infomation@gmail.com">CIR-KIT</author>
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>

--- a/waypoint_navigator/package.xml
+++ b/waypoint_navigator/package.xml
@@ -6,7 +6,7 @@
 
   <!-- <maintainer email="yuta@todo.todo">yuta</maintainer> -->
   <maintainer email="o111027y@mail.kyutech.jp">Doi Yusuke</maintainer>
-  <license>MIT</license>
+  <license>BSD</license>
 
   <url type="repository">https://github.com/CIR-KIT/waypoint_manager.git</url>
   <url type="bugtracker">https://github.com/CIR-KIT/waypoint_manager/issues</url>

--- a/waypoint_navigator/package.xml
+++ b/waypoint_navigator/package.xml
@@ -10,7 +10,7 @@
 
   <url type="repository">https://github.com/CIR-KIT/waypoint_manager.git</url>
   <url type="bugtracker">https://github.com/CIR-KIT/waypoint_manager/issues</url>
-  <!-- TODO: write this <author email="jane.doe@example.com">Jane Doe</author> -->
+  <author email="cirkit.infomation@gmail.com">CIR-KIT</author>
 
   <buildtool_depend>catkin</buildtool_depend>
   <depend>roscpp</depend>


### PR DESCRIPTION
- Migrate to BSD License from MIT License
- Add author tag on package.xml for CIR-KIT

ライセンス変更のプルリクエストです。