### PR TITLE
Reformat navigator pkg

### DIFF
--- a/waypoint_navigator/include/ros_colored_msg.h
+++ b/waypoint_navigator/include/ros_colored_msg.h
@@ -1,10 +1,8 @@
 // Defining your own ROS stream color
 // https://gist.github.com/artivis/51c6c9436481b16cab2f
 // auther : artivis
-namespace pc
-{
-  enum PRINT_COLOR
-  {
+namespace pc {
+  enum PRINT_COLOR {
     BLACK,
     RED,
     GREEN,
@@ -16,10 +14,8 @@ namespace pc
     ENDCOLOR
   };
 
-  std::ostream& operator<<(std::ostream& os, PRINT_COLOR c)
-  {
-    switch(c)
-    {
+  std::ostream& operator<<(std::ostream& os, PRINT_COLOR c) {
+    switch(c) {
       case BLACK    : os << "\033[1;30m"; break;
       case RED      : os << "\033[1;31m"; break;
       case GREEN    : os << "\033[1;32m"; break;

--- a/waypoint_navigator/include/ros_colored_msg.h
+++ b/waypoint_navigator/include/ros_colored_msg.h
@@ -31,7 +31,7 @@ namespace pc
       case ENDCOLOR : os << "\033[0m";    break;
       default       : os << "\033[1;37m";
     }
-return os;
+    return os;
   }
 } //namespace pc
 

--- a/waypoint_navigator/test/waypoint_navigator.test.xml
+++ b/waypoint_navigator/test/waypoint_navigator.test.xml
@@ -1,5 +1,5 @@
 <launch>
   <include file="$(find waypoint_navigator)/launch/waypoint_navigator.launch">
-	<arg name="waypoint_filename" value="$(find waypoint_navigator)/waypoints/2016-11-06-11-32-09.csv"/>
+    <arg name="waypoint_filename" value="$(find waypoint_navigator)/waypoints/2016-11-06-11-32-09.csv"/>
   </include>
 </launch>

--- a/waypoint_navigator/test/waypoint_navigator_gazebo.test.xml
+++ b/waypoint_navigator/test/waypoint_navigator_gazebo.test.xml
@@ -1,5 +1,5 @@
 <launch>
   <include file="$(find waypoint_navigator)/launch/waypoint_navigator_gazebo.launch">
-	<arg name="waypoint_filename" value="$(find waypoint_navigator)/waypoints/gazebo_waypoints.csv"/>
+    <arg name="waypoint_filename" value="$(find waypoint_navigator)/waypoints/gazebo_waypoints.csv"/>
   </include>
 </launch>


### PR DESCRIPTION
記法統一の第一歩。
- test の launchにタブ文字が混ざっていたので撲滅
- if, for, while にスペースが入ってたり入ってなかったりするので全部いつもの(自分派閥)に統一
- Constructor initialization list(コンストラクトリストって言ってるやつ)は必ず改行するように変更
- 関数, メソッド の 定義もいつもの(自分派閥)に統一