### PR TITLE
Fix depend packages

### DIFF
--- a/cirkit_waypoint_generator/CMakeLists.txt
+++ b/cirkit_waypoint_generator/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   tf
   visualization_msgs
+  cirkit_waypoint_manager_msgs
 )
 
 find_package(Boost 1.4 COMPONENTS program_options REQUIRED)


### PR DESCRIPTION
cirkit_waypoint_generator が cirkit_waypoint_manager_msgs に依存しているが、
CmakeLists.txt でfind_package していないため、メッセージのヘッダーファイルが認識されない問題があったので、修正しました。